### PR TITLE
fixes UI issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       <li><a href="html-quiz.html"class="quiz-link">HTML Quiz</a></li>
       <li><a href="css-quiz.html"class="quiz-link">CSS Quiz</a></li>
       <li><a href="js-quiz.html"class="quiz-link">JavaScript Quiz</a></li>
-      <li><a href="cpp-quiz.html">C++ Quiz</a></li>
+      <li><a href="cpp-quiz.html" class="quiz-link">C++ Quiz</a></li>
       <li><a href="react-quiz.html" class="quiz-link">React Quiz</a></li>
       <li><a href="nextjs-quiz.html" class="quiz-link">Next.js Quiz</a></li>
       <li><a href="git-quiz.html" class="quiz-link">Git & GitHub Quiz</a></li>


### PR DESCRIPTION
Describe the bug / feature
C++ link does not match with other buttons

closes #128 

Expected behavior: 
blue button for C++

Actual behavior: 
blue link for C++



Screenshots:
<img width="1920" height="1200" alt="Screenshot (107)" src="https://github.com/user-attachments/assets/747c3f35-e1f9-4e0c-b596-15bd283c780f" />

