### PR TITLE
fixed the  Enhancement: Track Attempted Questions with Status & Disab…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "livePreview.defaultPreviewPath": "/index.html"
+}


### PR DESCRIPTION
 (Issue #58)
fixed the  Enhancement: Track Attempted Questions with Status & Disable 
The error was that attempted questions were tracked globally, causing all quiz sections to share the same attempt status.
Now, each quiz section tracks its own attempted questions separately, so users can answer questions independently in each topic.
now it works properly as well as showing if the qs nt attempted