### PR TITLE
removed "-->" from index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Quiz Game</title>
   <link rel="stylesheet" href="styles.css">
-  <!-- <--<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">--> -->
+  <!-- <--<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">-->
 
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
removed "-->" from index page, looks like it was an accidental symbol that was visible on the main page of the quiz above the navigation bar.
<img width="811" height="253" alt="Screenshot 2025-07-26 192835" src="https://github.com/user-attachments/assets/5c56ebd1-c79a-4d23-8bdf-f669e63e7062" />
